### PR TITLE
remove null items from list before making it fancy

### DIFF
--- a/user-lock-manager.smartapp.groovy
+++ b/user-lock-manager.smartapp.groovy
@@ -311,7 +311,7 @@ def deviceLabel(device) {
 }
 
 def fancyString(listOfStrings) {
-
+  listOfStrings.removeAll([null])
   def fancify = { list ->
     return list.collect {
       def label = it


### PR DESCRIPTION
This fixes the issue of items in the list being `null` and you getting the following:

![img_7805](https://cloud.githubusercontent.com/assets/32551/7054942/b04c607e-de05-11e4-9ba5-2d5e3506f956.PNG)
