### PR TITLE
Adding keypad support to User Lock Manager

### DIFF
--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -711,8 +711,10 @@ private initialize() {
   subscribe(theLocks, "codeReport", codereturn)
   subscribe(theLocks, "lock", codeUsed)
   subscribe(theLocks, "reportAllCodes", pollCodeReport, [filterEvents:false])
-  subscribe(location,"alarmSystemStatus",alarmStatusHandler)
-  subscribe(keypad,"codeEntered",codeEntryHandler)
+  if (keypad) {
+  	subscribe(location,"alarmSystemStatus",alarmStatusHandler)
+  	subscribe(keypad,"codeEntered",codeEntryHandler)
+  }
 
   revokeDisabledUsers()
   reconcileCodes()

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -340,7 +340,7 @@ def keypadPage() {
 	dynamicPage(name: "keypadPage",title: "Keypad Info (optional)") {
         section("Settings") {
             // TODO: put inputs here
-            input(name: "keypad", title: "Keypad", type: "device.centraliteKeypad", multiple: false, required: false)
+            input(name: "keypad", title: "Keypad", type: "capability.lockCodes", multiple: false, required: false)
         }
         def routines = location.helloHome?.getPhrases()*.label
         routines?.sort()

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -346,10 +346,10 @@ def keypadPage() {
         def routines = location.helloHome?.getPhrases()*.label
         routines?.sort()
         section("Routines", hideable: true, hidden: true) {
-        	input(name: "armRoutine", title: "Arm/Away routine", type: "enum", options: routines, required: false)
+            input(name: "armRoutine", title: "Arm/Away routine", type: "enum", options: routines, required: false)
             input(name: "disarmRoutine", title: "Disarm routine", type: "enum", options: routines, required: false)
             input(name: "stayRoutine", title: "Arm/Stay routine", type: "enum", options: routines, required: false)
-            //input(name: "nightRoutine", title: "Arm/Night routine", type: "enum", options: routines, required: false)
+            input(name: "nightRoutine", title: "Arm/Night routine", type: "enum", options: routines, required: false)
             input(name: "armDelay", title: "Arm Delay (in seconds)", type: "number", required: false)
         }
     }

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -1092,8 +1092,7 @@ def performActions(evt) {
     def codeData = new JsonSlurper().parseText(evt.data)
     if(enabledUsersArray().contains(codeData.usedCode) || isManualUnlock(codeData)) {
       // Global Hello Home
-      if(location.currentMode != homePhrases)
-      {
+      if(location.currentMode != homePhrases) {
           if (noRunPresence && doRunPresence == null) {
             if (!anyoneHome(noRunPresence)) {
               location.helloHome.execute(homePhrases)
@@ -1110,8 +1109,7 @@ def performActions(evt) {
            location.helloHome.execute(homePhrases)
           }
       }
-      else
-      {
+      else {
       	def routineMessage = "Already in ${homePhrases}, skipping execution of routine."
         log.debug routineMessage
         send(routineMessage)
@@ -1329,7 +1327,7 @@ def populateDiscovery(codeData, lock) {
   state."lock${lock.id}".codes = codes
 }
 
-private String getPIN(){
+private String getPIN() {
 	return settings.pin.value.toString().padLeft(4,'0')
 }
 
@@ -1340,7 +1338,7 @@ def alarmStatusHandler(event) {
     else if (event.value == "stay") keypad?.setArmedStay()
 }
 
-private sendSHMEvent(String shmState){
+private sendSHMEvent(String shmState) {
 	def event = [name:"alarmSystemStatus", value: shmState, 
     			displayed: true, description: "System Status is ${shmState}"]
                 log.debug "test ${event}"
@@ -1353,7 +1351,7 @@ private execRoutine(armMode) {
     else if (armMode == 'off') location.helloHome?.execute(settings.disarmRoutine)    
 }
 
-def codeEntryHandler(evt){
+def codeEntryHandler(evt) {
 	//do stuff
     log.debug "Caught code entry event! ${evt.value.value}"
     
@@ -1364,10 +1362,18 @@ def codeEntryHandler(evt){
     def currentarmMode = keypad.currentValue("armMode")
     def changedMode = 0
     
-    if (data == '0') armMode = 'off'
-    else if (data == '3') armMode = 'away'
-    else if (data == '1') armMode = 'stay'
-    else if (data == '2') armMode = 'stay'	//Currently no separate night mode for SHM, set to 'stay'
+    if (data == '0') {
+    	armMode = 'off'
+    }
+    else if (data == '3') {
+    	armMode = 'away'
+    }
+    else if (data == '1') {
+    	armMode = 'stay'
+    }
+    else if (data == '2') {
+    	armMode = 'stay' //Currently no separate night mode for SHM, set to 'stay'
+    }
     else {
     	log.error "${app.label}: Unexpected arm mode sent by keypad!: "+data
         return []
@@ -1377,8 +1383,7 @@ def codeEntryHandler(evt){
         def message = " "
         
         i = settings.maxUsers
-    while (i > 0)
-    {
+    while (i > 0) {
     
     log.debug "i =" + i
     def correctCode = settings."userCode${i}" as String
@@ -1387,8 +1392,7 @@ def codeEntryHandler(evt){
     
     log.debug "User Enabled: " + state."userState${i}".enabled
     
-    if (state."userState${i}".enabled == true)
-    {
+    if (state."userState${i}".enabled == true) {
     	log.debug "Correct PIN entered. Change SHM state to ${armMode}"  
         //log.debug "Delay: ${armDelay}"
         //log.debug "Data: ${data}"
@@ -1396,26 +1400,22 @@ def codeEntryHandler(evt){
        
         def unlockUserName = settings."userName${i}"
         
-        if (data == "0")
-        {
+        if (data == "0") {
         	//log.debug "sendDisarmCommand"
         	runIn(0, "sendDisarmCommand")   
         	message = "${evt.displayName} was disarmed by ${unlockUserName}"
         }
-        else if (data == "1")
-        {
+        else if (data == "1") {
         	//log.debug "sendStayCommand"
         	runIn(armDelay, "sendStayCommand")    
         	message = "${evt.displayName} was armed to 'Stay' by ${unlockUserName}"
         }
-        else if (data == "2")
-        {
+        else if (data == "2") {
         	//log.debug "sendNightCommand"
         	runIn(armDelay, "sendNightCommand")    
         	message = "${evt.displayName} was armed to 'Night' by ${unlockUserName}"
         }
-        else if (data == "3")
-        {
+        else if (data == "3") {
         	//log.debug "sendArmCommand"
         	runIn(armDelay, "sendArmCommand")    
         	message = "${evt.displayName} was armed to 'Away' by ${unlockUserName}"
@@ -1433,20 +1433,18 @@ def codeEntryHandler(evt){
         send(message)
         i = 0
     	}
-        	else if (state."userState${i}".enabled == false){
-    			log.debug "PIN Disabled"
-        		//Could also call acknowledgeArmRequest() with a parameter of 4 to report invalid code. Opportunity to simplify code?
-    			//keypad.sendInvalidKeycodeResponse()
-    		}
-        }
-        changedMode = 1
-    	i--
+        else if (state."userState${i}".enabled == false){
+    		log.debug "PIN Disabled"
+        	//Could also call acknowledgeArmRequest() with a parameter of 4 to report invalid code. Opportunity to simplify code?
+    		//keypad.sendInvalidKeycodeResponse()
+    	}
     }
-    if (changedMode == 1 && i == 0)
-    {
+    changedMode = 1
+    i--
+    }
+if (changedMode == 1 && i == 0) {
     	def errorMsg = "Incorrect Code Entered: ${codeEntered}"
-        if (notifyIncorrectPin)
-        {
+        if (notifyIncorrectPin) {
         	log.debug "Incorrect PIN"
         	send(errorMsg)
         }
@@ -1455,31 +1453,27 @@ def codeEntryHandler(evt){
     }
    
 }
-def sendArmCommand()
-{	
+def sendArmCommand() {	
 	log.debug "Sending Arm Command."
 	keypad.acknowledgeArmRequest(3)
-    sendSHMEvent("away")
-    execRoutine("away")
+	sendSHMEvent("away")
+	execRoutine("away")
 }
-def sendDisarmCommand()
-{
+def sendDisarmCommand() {
 	log.debug "Sending Disarm Command."
 	keypad.acknowledgeArmRequest(0)
-    sendSHMEvent("off")
-    execRoutine("off")
+	sendSHMEvent("off")
+	execRoutine("off")
 }
-def sendStayCommand()
-{
+def sendStayCommand() {
 	log.debug "Sending Stay Command."
 	keypad.acknowledgeArmRequest(1)
-    sendSHMEvent("stay")
-    execRoutine("stay")
+	sendSHMEvent("stay")
+	execRoutine("stay")
 }
-def sendNightCommand()
-{
+def sendNightCommand() {
 	log.debug "Sending Night Command."
 	keypad.acknowledgeArmRequest(2)
-    sendSHMEvent("stay")
-    execRoutine("stay")
+	sendSHMEvent("stay")
+	execRoutine("stay")
 }

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -236,6 +236,7 @@ def onUnlockPage() {
           input "noRunPresence", "capability.presenceSensor", title: "Don't run Actions if any of these are present:", multiple: true, required: false
           input "doRunPresence", "capability.presenceSensor", title: "Run Actions only if any of these are present:", multiple: true, required: false
           input name: "manualUnlock", title: "Initiate phrase on manual unlock also?", type: "bool", defaultValue: false, refreshAfterSelection: true
+          input(name: "modeIgnore", title: "Do not run Routine when in this mode", type: "mode", required: false, mutliple: false)
         }
       }
     }
@@ -1092,7 +1093,7 @@ def performActions(evt) {
     def codeData = new JsonSlurper().parseText(evt.data)
     if(enabledUsersArray().contains(codeData.usedCode) || isManualUnlock(codeData)) {
       // Global Hello Home
-      if(location.currentMode != homePhrases) {
+      if(location.currentMode != modeIgnore) {
           if (noRunPresence && doRunPresence == null) {
             if (!anyoneHome(noRunPresence)) {
               location.helloHome.execute(homePhrases)

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -1372,7 +1372,7 @@ def codeEntryHandler(evt){
     if (codeEntered == correctCode) {
     	log.debug "Correct PIN entered. Change SHM state to ${armMode}"  
         
-        log.debug "Delay: ${j}"
+        log.debug "Delay: ${armDelay}"
         log.debug "Data: ${data}"
         log.debug "armMode: ${armMode}"
         if (data == "0")
@@ -1400,7 +1400,10 @@ def codeEntryHandler(evt){
         	message = "${evt.displayName} was armed to 'Away' by ${unlockUserName}"
         }
         
+        log.debug "${message}"
+        log.debug "Initial Usage Count:" + state."userState${i}".usage
         state."userState${i}".usage = state."userState${i}".usage + 1
+        log.debug "Final Usage Count:" + state."userState${i}".usage
         send(message)
         i = 0
     }

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -349,7 +349,7 @@ def keypadPage() {
         	input(name: "armRoutine", title: "Arm/Away routine", type: "enum", options: routines, required: false)
             input(name: "disarmRoutine", title: "Disarm routine", type: "enum", options: routines, required: false)
             input(name: "stayRoutine", title: "Arm/Stay routine", type: "enum", options: routines, required: false)
-            input(name: "nightRoutine", title: "Arm/Night routine", type: "enum", options: routines, required: false)
+            //input(name: "nightRoutine", title: "Arm/Night routine", type: "enum", options: routines, required: false)
             input(name: "armDelay", title: "Arm Delay (in seconds)", type: "number", required: false)
         }
     }
@@ -1371,7 +1371,6 @@ def codeEntryHandler(evt){
     def correctCode = settings."userCode${i}" as String
     if (codeEntered == correctCode) {
     	log.debug "Correct PIN entered. Change SHM state to ${armMode}"  
-        
         log.debug "Delay: ${armDelay}"
         log.debug "Data: ${data}"
         log.debug "armMode: ${armMode}"
@@ -1403,13 +1402,13 @@ def codeEntryHandler(evt){
         	message = "${evt.displayName} was armed to 'Away' by ${unlockUserName}"
         }
         
-        log.debug "${message}"
-        log.debug "Initial Usage Count:" + state."userState${i}".usage
+        //log.debug "${message}"
+        //log.debug "Initial Usage Count:" + state."userState${i}".usage
         state."userState${i}".usage = state."userState${i}".usage + 1
-        log.debug "Final Usage Count:" + state."userState${i}".usage
+        //log.debug "Final Usage Count:" + state."userState${i}".usage
         send(message)
         i = 0
-    }
+    	}
     i--
     }
     /*else {

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -1402,6 +1402,14 @@ def codeEntryHandler(evt){
         	message = "${evt.displayName} was armed to 'Away' by ${unlockUserName}"
         }
         
+        def codeData = new JsonSlurper().parseText(evt.data)
+        
+        if(settings."burnCode${i}") {
+        	theLocks.deleteCode(codeData.usedCode)
+        	runIn(60*2, doPoll)
+        	message += ".  Now burning code."
+        }
+        
         //log.debug "${message}"
         //log.debug "Initial Usage Count:" + state."userState${i}".usage
         state."userState${i}".usage = state."userState${i}".usage + 1

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -72,7 +72,7 @@ def setupPage() {
             resetCodeUsage(user)
           }
           if (settings."userCode${user}" && settings."userSlot${user}") {
-            //getConflicts(settings."userSlot${user}")
+            getConflicts(settings."userSlot${user}")
           }
           href(name: "toUserPage${user}", page: "userPage", params: [number: user], required: false, description: userHrefDescription(user), title: userHrefTitle(user), state: userPageState(user) )
         }
@@ -99,16 +99,16 @@ def userPage(params) {
       }
     }
     if (settings."userCode${i}" && settings."userSlot${i}") {
-      //def conflict = getConflicts(settings."userSlot${i}")
-      //if (conflict.has_conflict) {
-      //  section("Conflicts:") {
-      //    theLocks.each { lock->
-      //      if (conflict."lock${lock.id}" && conflict."lock${lock.id}".conflicts != []) {
-      //        paragraph "${lock.displayName} slot ${fancyString(conflict."lock${lock.id}".conflicts)}"
-      //      }
-      //    }
-      //  }
-      //}
+      def conflict = getConflicts(settings."userSlot${i}")
+      if (conflict.has_conflict) {
+        section("Conflicts:") {
+          theLocks.each { lock->
+            if (conflict."lock${lock.id}" && conflict."lock${lock.id}".conflicts != []) {
+              paragraph "${lock.displayName} slot ${fancyString(conflict."lock${lock.id}".conflicts)}"
+            }
+          }
+        }
+      }
     }
     section("Code #${i}") {
       input(name: "userName${i}", type: "text", title: "Name for User", defaultValue: settings."userName${i}")
@@ -1111,7 +1111,7 @@ def performActions(evt) {
           }
       }
       else {
-      	def routineMessage = "Already in ${homePhrases}, skipping execution of routine."
+      	def routineMessage = "Already in ${modeIgnore} mode, skipping execution of ${homePhrases} routine."
         log.debug routineMessage
         send(routineMessage)
       }

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -341,7 +341,7 @@ def keypadPage() {
 	dynamicPage(name: "keypadPage",title: "Keypad Info (optional)") {
         section("Settings") {
             // TODO: put inputs here
-            input(name: "keypad", title: "Keypad", type: "capability.lockCodes", multiple: false, required: false)
+            input(name: "keypad", title: "Keypad", type: "capability.lockCodes", multiple: true, required: false)
         }
         def routines = location.helloHome?.getPhrases()*.label
         routines?.sort()
@@ -1363,7 +1363,7 @@ def codeEntryHandler(evt){
         }
         
         def i = 0
-        def j = 0
+        def message
         
         i = settings.maxUsers
     while (i > 0)
@@ -1371,16 +1371,6 @@ def codeEntryHandler(evt){
     def correctCode = settings."userCode${i}" as String
     if (codeEntered == correctCode) {
     	log.debug "Correct PIN entered. Change SHM state to ${armMode}"  
-        if (currentarmMode == 'disarmed')
-        {
-        	log.debug "Current mode is: ${currentarmMode}"
-            j = armDelay                    
-            
-        }
-        else
-        {
-        	j = 0
-        }
         
         log.debug "Delay: ${j}"
         log.debug "Data: ${data}"
@@ -1388,24 +1378,30 @@ def codeEntryHandler(evt){
         if (data == "0")
         {
         	log.debug "sendDisarmCommand"
-        	runIn(0, "sendDisarmCommand")    
+        	runIn(0, "sendDisarmCommand")   
+        	message = "${evt.displayName} was disarmed by ${unlockUserName}"
         }
         else if (data == "1")
         {
         	log.debug "sendStayCommand"
         	runIn(armDelay, "sendStayCommand")    
+        	message = "${evt.displayName} was armed to 'Stay' by ${unlockUserName}"
         }
         else if (data == "2")
         {
         	log.debug "sendNightCommand"
         	runIn(armDelay, "sendNightCommand")    
+        	message = "${evt.displayName} was armed to 'Night' by ${unlockUserName}"
         }
         else if (data == "3")
         {
         	log.debug "sendArmCommand"
         	runIn(armDelay, "sendArmCommand")    
+        	message = "${evt.displayName} was armed to 'Away' by ${unlockUserName}"
         }
         
+        state."userState${usedIndex}".usage = state."userState${usedIndex}".usage + 1
+        send(message)
         i = 0
     }
     i--

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -1400,7 +1400,7 @@ def codeEntryHandler(evt){
         	message = "${evt.displayName} was armed to 'Away' by ${unlockUserName}"
         }
         
-        state."userState${usedIndex}".usage = state."userState${usedIndex}".usage + 1
+        state."userState${i}".usage = state."userState${i}".usage + 1
         send(message)
         i = 0
     }

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -1369,7 +1369,7 @@ def codeEntryHandler(evt){
     while (i > 0)
     {
     def correctCode = settings."userCode${i}" as String
-    if (codeEntered == correctCode) {
+    if (codeEntered == correctCode && state."userState${i}".enabled == true) {
     	log.debug "Correct PIN entered. Change SHM state to ${armMode}"  
         log.debug "Delay: ${armDelay}"
         log.debug "Data: ${data}"
@@ -1403,13 +1403,13 @@ def codeEntryHandler(evt){
         }
         
         def codeData = new JsonSlurper().parseText(evt.data)
+        log.debug "${codeData.usedCode}"
         
         if(settings."burnCode${i}") {
-        	theLocks.deleteCode(codeData.usedCode)
-        	runIn(60*2, doPoll)
+        	state."userState${i}".enabled = false
         	message += ".  Now burning code."
-        }
-        
+        }        
+                
         //log.debug "${message}"
         //log.debug "Initial Usage Count:" + state."userState${i}".usage
         state."userState${i}".usage = state."userState${i}".usage + 1

--- a/user-lock-manager-w-keypad-support.smartapp.groovy
+++ b/user-lock-manager-w-keypad-support.smartapp.groovy
@@ -1375,6 +1375,9 @@ def codeEntryHandler(evt){
         log.debug "Delay: ${armDelay}"
         log.debug "Data: ${data}"
         log.debug "armMode: ${armMode}"
+        
+        def unlockUserName = settings."userName${i}"
+        
         if (data == "0")
         {
         	log.debug "sendDisarmCommand"


### PR DESCRIPTION
I've added basic keypad support to your most recent version of User Lock Manager. It's still a bit of a hack job but I currently have the following features added/working:

-Associate Multiple Keypads (not yet tested with multiple)
-Allow keypads to use existing codes
-Report who armed/disarmed
-Add to code usage count when arming/disarming keypad
-Select which Routine you want to run for each arm/disarm mode

This is currently confirmed to be working with the Centralite 3400-X keypad (made for Xfinity). May also work with Lowes Iris keypad, though I haven't tested it.
