### PR TITLE
Modification for Schlage BE369

### DIFF
--- a/user-lock-manager.smartapp.groovy
+++ b/user-lock-manager.smartapp.groovy
@@ -1015,7 +1015,7 @@ def codereturn(evt) {
 
 def usedUserIndex(usedSlot) {
   for (int i = 1; i <= settings.maxUsers; i++) {
-    if (settings."userSlot${i}".toInteger() == usedSlot.toInteger()) {
+    if (settings."userSlot${i}" && settings."userSlot${i}".toInteger() == usedSlot.toInteger()) {
       return i
     }
   }


### PR DESCRIPTION
The Schlage BE369 do not report user code, it report NULL. With this modification you can at less known when a code is used.

this was causing a null pointer exception.
