### PR TITLE
Modification for Schlage BE369

### DIFF
--- a/zwave-lock.groovy
+++ b/zwave-lock.groovy
@@ -602,7 +602,7 @@ def updateCodes(codeSettings) {
   def get_cmds = []
   codeSettings.each { name, updated ->
     def current = decrypt(state[name])
-    if (name.startsWith("code")) {
+    if (name.startsWith("code") && name[4..7] != "null") {
       def n = name[4..-1].toInteger()
       log.debug "$name was $current, set to $updated"
       if (updated?.size() >= 4 && updated != current) {


### PR DESCRIPTION
The Schlage BE369 do not report user code. it report NULL instead. 
For the code to work, i just add a "null" string check.

There's maybe a better way to do it. I did not read all your code.
