### PR TITLE
Real Time Lock Data info fix

### DIFF
--- a/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
+++ b/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
@@ -539,13 +539,14 @@ def poll() {
 	}
 	if (cmds) {
 		log.debug "poll is sending ${cmds.inspect()}"
-    reportAllCodes(state)
 		cmds
 	} else {
 		// workaround to keep polling from stopping due to lack of activity
 		sendEvent(descriptionText: "skipping poll", isStateChange: true, displayed: false)
 		null
 	}
+
+    reportAllCodes(state)
 }
 
 def requestCode(codeNumber) {


### PR DESCRIPTION
Sometime after 4.0.9 was released, SmartThings made a change to their
default Z-Wave Lock Device Handler. In this update the poll() function
was changed and reportAllCodes was added to an if statement that does
not occur immediately when the lock data refresh is triggered.

As best as I can tell, this is due to “cmds” only being set if the
conditions of the lock
state or update time is met in the previous if/else statement.

Because of this the lock data does not get refreshed in real time or at
all (not sure if it gets set in certain cases).

Removing “reportAllCodes(state)” out of the if statement and separating
it out by itself allows real time updating like previous versions of
the smart app.
