### PR TITLE
Lock Data info not working

### DIFF
--- a/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
+++ b/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
@@ -539,13 +539,14 @@ def poll() {
 	}
 	if (cmds) {
 		log.debug "poll is sending ${cmds.inspect()}"
-    reportAllCodes(state)
 		cmds
 	} else {
 		// workaround to keep polling from stopping due to lack of activity
 		sendEvent(descriptionText: "skipping poll", isStateChange: true, displayed: false)
 		null
 	}
+
+    reportAllCodes(state)
 }
 
 def requestCode(codeNumber) {

--- a/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
+++ b/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
@@ -539,7 +539,6 @@ def poll() {
 	}
 	if (cmds) {
 		log.debug "poll is sending ${cmds.inspect()}"
-        reportAllCodes(state)
 		cmds
 	} else {
 		// workaround to keep polling from stopping due to lack of activity

--- a/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
+++ b/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
@@ -539,6 +539,7 @@ def poll() {
 	}
 	if (cmds) {
 		log.debug "poll is sending ${cmds.inspect()}"
+        reportAllCodes(state)
 		cmds
 	} else {
 		// workaround to keep polling from stopping due to lack of activity

--- a/smartapps/ethayer/user-lock-manager.src/user-lock-manager.groovy
+++ b/smartapps/ethayer/user-lock-manager.src/user-lock-manager.groovy
@@ -1361,7 +1361,7 @@ def populateDiscovery(codeData, lock) {
   (1..codeSlots).each { slot->
     codes."slot${slot}" = codeData."code${slot}"
   }
-  atomicState."lock${lock.id}".codes = codes
+  state."lock${lock.id}".codes = codes
 }
 
 private String getPIN() {


### PR DESCRIPTION
When I was updating from V 4.0.9 I tested the Lock Info page and the codes were not updating in the lock info screen.

The first issue I noticed was in the device handler where the "reportAllCodes(state)" was not being called so I removed that. The Lock info still did not function properly so I reverted the smart app only back to v 4.0.9 and incrementally tested each release until I was able to pinpoint the change that caused the lock info page to stop working. 

The change from "state" to "atomicState" caused the error. Subsequently making the changing in V4.1.5 back to "state" fixes the lock info page.

This error may be due to the fact that atomicState is not supported in Device Handlers at this time and also the combined use of state and atomicState within the same app. 

See http://docs.smartthings.com/en/latest/smartapp-developers-guide/state.html#atomic-state for reference.
