### PR TITLE
Updates unlocked, unlocking, and unknown states to use amber background color

### DIFF
--- a/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
+++ b/devicetypes/smartthings/zwave-lock-reporting.src/zwave-lock-reporting.groovy
@@ -39,10 +39,10 @@ metadata {
 		multiAttributeTile(name:"toggle", type: "generic", width: 6, height: 4){
 			tileAttribute ("device.lock", key: "PRIMARY_CONTROL") {
 				attributeState "locked", label:'locked', action:"lock.unlock", icon:"st.locks.lock.locked", backgroundColor:"#79b821", nextState:"unlocking"
-				attributeState "unlocked", label:'unlocked', action:"lock.lock", icon:"st.locks.lock.unlocked", backgroundColor:"#ffffff", nextState:"locking"
-				attributeState "unknown", label:"unknown", action:"lock.lock", icon:"st.locks.lock.unknown", backgroundColor:"#ffffff", nextState:"locking"
+				attributeState "unlocked", label:'unlocked', action:"lock.lock", icon:"st.locks.lock.unlocked", backgroundColor:"#ffa81e", nextState:"locking"
+				attributeState "unknown", label:"unknown", action:"lock.lock", icon:"st.locks.lock.unknown", backgroundColor:"#ffa81e", nextState:"locking"
 				attributeState "locking", label:'locking', icon:"st.locks.lock.locked", backgroundColor:"#79b821"
-				attributeState "unlocking", label:'unlocking', icon:"st.locks.lock.unlocked", backgroundColor:"#ffffff"
+				attributeState "unlocking", label:'unlocking', icon:"st.locks.lock.unlocked", backgroundColor:"#ffa81e"
 			}
 		}
 		standardTile("lock", "device.lock", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {


### PR DESCRIPTION
Updates the background color to that of the SmartSense open/close door
sensor device handler from SmartThings, which is an amber color to
denote the state of when the sensor is open. The amber color provides a
better visual indicator of caution when locks are either unlocked or
the state is unknown.

![img_5660](https://cloud.githubusercontent.com/assets/28156/17844575/bb6e4358-67ef-11e6-8598-3aff777afe71.PNG)
